### PR TITLE
Add deposit command handler and tests for frigged_deposit_command

### DIFF
--- a/boombot/core/bot.py
+++ b/boombot/core/bot.py
@@ -21,6 +21,8 @@ from boombot.handlers.base_handlers import (
 from boombot.handlers.roulette_handlers import start_roulette_command, roulette_callback_handler
 # Import beast handlers
 from boombot.handlers.beast_handlers import whowouldwin_command
+# Import deposit handlers
+from boombot.handlers.deposit_handlers import frigged_deposit_command
 from boombot.core.config import TELEGRAM_TOKEN # Corrected import name
 from boombot.games.zeus.zeus import zeus, spin_button  # Import Zeus handlers
 
@@ -65,6 +67,9 @@ def create_application(token: str) -> Application:
 
     # --- Beast Wars Handlers ---
     application.add_handler(CommandHandler("whowouldwin", whowouldwin_command))
+
+    # --- Deposit Handlers ---
+    application.add_handler(CommandHandler("friggedthedeposit", frigged_deposit_command))
 
     # --- Craps Game Handlers ---
     application.add_handler(CommandHandler("craps", start_craps_command))

--- a/boombot/handlers/deposit_handlers.py
+++ b/boombot/handlers/deposit_handlers.py
@@ -1,0 +1,64 @@
+import logging
+import random
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from boombot.utils.llm import get_openrouter_response
+
+logger = logging.getLogger(__name__)
+
+async def frigged_deposit_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handles the /friggedthedeposit command by generating a humorous story."""
+    if not update.message:
+        logger.warning("Received /friggedthedeposit but update.message is None")
+        return
+
+    name_provided = ""
+    if context.args:
+        name_provided = " ".join(context.args).strip()
+
+    if not name_provided:
+        await update.message.reply_text(
+            "Who frigged the deposit? Tell me their name!\\n"
+            "Usage: /friggedthedeposit [name]\\n"
+            "Example: /friggedthedeposit Kevin"
+        )
+        return
+
+    logger.info(f"Processing /friggedthedeposit request for: '{name_provided}'")
+
+    # The get_openrouter_response function wraps the question with:
+    # "Provide a concrete answer to the question in the form of a battle summary in a single line, being extremely dramatic: '{question}'"
+    # Our 'llm_question' should guide the LLM to the desired output format, leveraging the "extremely dramatic" part for humor.
+    llm_question = (
+        f"Generate a short, funny, hip, modern, or comically minor reason why '{name_provided}' "
+        f"lost the security deposit on a rental property. This is for an inside joke about 'frigging the deposit'. "
+        f"The answer should be a single, funny, non-corny sentence, ideally starting with '{name_provided} frigged the deposit by...'. "
+        f"Make it creative, absurd, and dramatic. "
+        f"For example: '{name_provided} frigged the deposit by entering a gun-free zone with a gun.'"
+        f" or '{name_provided} frigged the deposit by swimming in the septic tank.'"
+    )
+
+    try:
+        response = get_openrouter_response(llm_question)
+        logger.info(f"LLM response for {name_provided} (/friggedthedeposit): {response}")
+        
+        # Check if the response starts appropriately, if not, prepend.
+        # This is a simple check; the LLM should ideally follow the prompt's structure.
+        if not response.lower().startswith(name_provided.lower()):
+            # A more sophisticated check might be needed if the LLM is very creative.
+            # For now, we'll assume the LLM tries to include the name prominently.
+            # If the LLM often misses the "starts with name..." part, we might prepend:
+            # response = f"{name_provided} frigged the deposit in a most spectacular fashion! {response}" 
+            # However, the current llm.py prompt asks for a "battle summary", which might make it less likely to follow strictly.
+            # Let's rely on the prompt to guide the LLM first.
+            pass
+
+    except Exception as e:
+        logger.error(f"Error getting LLM response for /friggedthedeposit: {e}")
+        # Ensure 'random' is imported at the top of your file (e.g., import random)
+        tip_amount = random.randint(10, 200)
+        formatted_tip = f"${tip_amount:.2f}"
+        response = f"I tried to figure out how {name_provided} frigged the deposit, but it seems the deposit was returned, along with a tip of {formatted_tip} for excellent service."
+
+    await update.message.reply_text(response)

--- a/tests/test_deposit_handlers.py
+++ b/tests/test_deposit_handlers.py
@@ -1,0 +1,87 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from boombot.handlers.deposit_handlers import frigged_deposit_command
+
+# --- Fixtures for testing ---
+
+@pytest.fixture
+def mock_update():
+    """Creates a mock Update object with nested mocks."""
+    update = MagicMock(spec=Update)
+    update.message = MagicMock()
+    update.message.reply_text = AsyncMock()
+    return update
+
+@pytest.fixture
+def mock_context():
+    """Creates a mock ContextTypes object."""
+    context = MagicMock(spec=ContextTypes.DEFAULT_TYPE)
+    context.args = []
+    return context
+
+# --- Tests for frigged_deposit_command ---
+
+@pytest.mark.asyncio
+async def test_frigged_deposit_no_args(mock_update, mock_context):
+    """Test the command with no arguments (should show usage instructions)."""
+    await frigged_deposit_command(mock_update, mock_context)
+    
+    mock_update.message.reply_text.assert_awaited_once()
+    call_args = mock_update.message.reply_text.await_args[0][0]
+    assert "Who frigged the deposit?" in call_args
+    assert "Usage: /friggedthedeposit [name]" in call_args
+    assert "Example: /friggedthedeposit Kevin" in call_args
+
+@pytest.mark.asyncio
+@patch('boombot.handlers.deposit_handlers.get_openrouter_response')
+async def test_frigged_deposit_with_name_success(mock_get_openrouter_response, mock_update, mock_context):
+    """Test the command with a name, expecting a successful LLM response."""
+    test_name = "Kevin"
+    mock_context.args = [test_name]
+    expected_llm_response = f"{test_name} frigged the deposit by attempting to pay the landlord in glitter."
+    mock_get_openrouter_response.return_value = expected_llm_response
+    
+    await frigged_deposit_command(mock_update, mock_context)
+    
+    llm_call_args = mock_get_openrouter_response.call_args[0][0]
+    assert test_name in llm_call_args 
+    assert "frigged the deposit by" in llm_call_args # Check that the prompt is constructed correctly
+
+    mock_update.message.reply_text.assert_awaited_once_with(expected_llm_response)
+
+@pytest.mark.asyncio
+@patch('boombot.handlers.deposit_handlers.get_openrouter_response')
+@patch('boombot.handlers.deposit_handlers.random.randint')
+async def test_frigged_deposit_with_name_llm_error(mock_randint, mock_get_openrouter_response, mock_update, mock_context):
+    """Test the command with a name, simulating an error from the LLM."""
+    test_name = "Alice"
+    mock_context.args = [test_name]
+    mock_get_openrouter_response.side_effect = Exception("LLM API is down")
+    mock_randint.return_value = 100 # Mocking the random tip amount for deterministic test
+    
+    await frigged_deposit_command(mock_update, mock_context)
+    
+    llm_call_args = mock_get_openrouter_response.call_args[0][0]
+    assert test_name in llm_call_args
+
+    mock_update.message.reply_text.assert_awaited_once()
+    call_args = mock_update.message.reply_text.await_args[0][0]
+    assert f"I tried to figure out how {test_name} frigged the deposit" in call_args
+    assert "it seems the deposit was returned, along with a tip of $100.00 for excellent service." in call_args
+
+@pytest.mark.asyncio
+@patch('boombot.handlers.deposit_handlers.get_openrouter_response')
+async def test_frigged_deposit_llm_response_does_not_start_with_name(mock_get_openrouter_response, mock_update, mock_context):
+    """Test when LLM response doesn't start with the name, it should still send the raw LLM response."""
+    test_name = "Bob"
+    mock_context.args = [test_name]
+    llm_response_without_name = "By putting a trampoline in the living room to test newton's laws of motion, Jeremy Renner frigged the deposit."
+    mock_get_openrouter_response.return_value = llm_response_without_name
+    
+    await frigged_deposit_command(mock_update, mock_context)
+    
+    mock_update.message.reply_text.assert_awaited_once_with(llm_response_without_name)
+


### PR DESCRIPTION
This pull request introduces a new feature to handle a `/friggedthedeposit` command in the bot, allowing users to generate humorous responses about losing a security deposit. The changes include implementing the command, integrating it into the bot, and adding comprehensive tests to ensure its functionality.

### New Feature: `/friggedthedeposit` Command
* **Command Implementation**:
  - Added a new handler function `frigged_deposit_command` in `boombot/handlers/deposit_handlers.py`. This function generates a humorous response using an LLM or a fallback message in case of errors.
  - Integrated the command into the bot by importing the handler and registering it in the `create_application` function in `boombot/core/bot.py`. [[1]](diffhunk://#diff-73912536d4041a2c146923efffb87d830f422896b8f94c0148fb6edd3f6b2bf4R24-R25) [[2]](diffhunk://#diff-73912536d4041a2c146923efffb87d830f422896b8f94c0148fb6edd3f6b2bf4R71-R73)

### Testing Suite for the New Command
* **Unit Tests**:
  - Added a new test file `tests/test_deposit_handlers.py` with fixtures and tests for various scenarios, including:
    - No arguments provided (shows usage instructions).
    - Successful LLM response generation.
    - Handling LLM errors gracefully with a fallback message.
    - Verifying behavior when the LLM response does not start with the expected name.